### PR TITLE
Add basic MSSQL-backed server

### DIFF
--- a/db.js
+++ b/db.js
@@ -1,0 +1,21 @@
+const sql = require('mssql');
+
+const config = {
+  user: process.env.DB_USER || 'Admin1',
+  password: process.env.DB_PASSWORD || 'Ab1',
+  server: process.env.DB_SERVER || 'localhost',
+  database: process.env.DB_NAME || 'LunchBox1',
+  options: {
+    encrypt: false,
+    trustServerCertificate: true
+  }
+};
+
+const pool = new sql.ConnectionPool(config);
+const poolConnect = pool.connect();
+
+module.exports = {
+  sql,
+  pool,
+  poolConnect
+};

--- a/db.js
+++ b/db.js
@@ -1,4 +1,5 @@
 const sql = require('mssql');
+require('dotenv').config();
 
 const config = {
   user: process.env.DB_USER || 'Admin1',
@@ -14,8 +15,14 @@ const config = {
 const pool = new sql.ConnectionPool(config);
 const poolConnect = pool.connect();
 
+async function getRequest() {
+  await poolConnect;
+  return pool.request();
+}
+
 module.exports = {
   sql,
   pool,
-  poolConnect
+  poolConnect,
+  getRequest
 };

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,0 +1,16 @@
+const jwt = require('jsonwebtoken');
+
+module.exports = function (req, res, next) {
+  const authHeader = req.headers['authorization'];
+  if (!authHeader) return res.status(401).json({ message: 'Missing authorization header' });
+  const token = authHeader.split(' ')[1];
+  if (!token) return res.status(401).json({ message: 'No token provided' });
+
+  try {
+    const user = jwt.verify(token, process.env.JWT_SECRET || 'secret');
+    req.user = user;
+    next();
+  } catch (err) {
+    return res.status(401).json({ message: 'Invalid token' });
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "node1",
+  "version": "1.0.0",
+  "description": "本專案為一個公司內部使用的訂便當系統，提供員工線上點餐、查詢訂單、管理便當項目與統計每日訂單狀況，並支援使用者註冊 / 登入 / 權限管理功能。",
+  "main": "server.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2",
+    "mssql": "^9.1.1",
+    "bcrypt": "^5.1.0",
+    "jsonwebtoken": "^9.0.1",
+    "dotenv": "^16.0.3"
+  }
+}

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,0 +1,27 @@
+const express = require('express');
+const bcrypt = require('bcrypt');
+const jwt = require('jsonwebtoken');
+const { sql, poolConnect } = require('../db');
+
+const router = express.Router();
+
+router.post('/login', async (req, res) => {
+  await poolConnect;
+  const { username, password } = req.body;
+  try {
+    const result = await sql.query`SELECT Id, PasswordHash, Role FROM Users WHERE Username = ${username}`;
+    if (result.recordset.length === 0) {
+      return res.status(401).json({ message: 'Invalid credentials' });
+    }
+    const user = result.recordset[0];
+    const match = await bcrypt.compare(password, user.PasswordHash);
+    if (!match) return res.status(401).json({ message: 'Invalid credentials' });
+    const token = jwt.sign({ id: user.Id, role: user.Role }, process.env.JWT_SECRET || 'secret');
+    res.json({ token });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+module.exports = router;

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,15 +1,17 @@
 const express = require('express');
 const bcrypt = require('bcrypt');
 const jwt = require('jsonwebtoken');
-const { sql, poolConnect } = require('../db');
+const { sql, getRequest } = require('../db');
 
 const router = express.Router();
 
 router.post('/login', async (req, res) => {
-  await poolConnect;
   const { username, password } = req.body;
   try {
-    const result = await sql.query`SELECT Id, PasswordHash, Role FROM Users WHERE Username = ${username}`;
+    const request = await getRequest();
+    const result = await request
+      .input('username', sql.NVarChar, username)
+      .query('SELECT Id, PasswordHash, Role FROM Users WHERE Username = @username');
     if (result.recordset.length === 0) {
       return res.status(401).json({ message: 'Invalid credentials' });
     }

--- a/routes/orders.js
+++ b/routes/orders.js
@@ -1,0 +1,32 @@
+const express = require('express');
+const { sql, poolConnect } = require('../db');
+const auth = require('../middleware/auth');
+
+const router = express.Router();
+
+router.post('/', auth, async (req, res) => {
+  await poolConnect;
+  const userId = req.user.id;
+  const { menuId, note } = req.body;
+  try {
+    await sql.query`INSERT INTO Orders (UserId, MenuId, OrderDate, Note) VALUES (${userId}, ${menuId}, GETDATE(), ${note})`;
+    res.json({ message: 'Order placed' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.get('/mine', auth, async (req, res) => {
+  await poolConnect;
+  const userId = req.user.id;
+  try {
+    const result = await sql.query`SELECT * FROM Orders WHERE UserId = ${userId}`;
+    res.json(result.recordset);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const express = require('express');
 const authRoutes = require('./routes/auth');
 const orderRoutes = require('./routes/orders');
@@ -5,6 +6,7 @@ const { poolConnect } = require('./db');
 
 const app = express();
 app.use(express.json());
+app.use(express.urlencoded({ extended: false }));
 
 app.use('/api', authRoutes);
 app.use('/api/orders', orderRoutes);

--- a/server.js
+++ b/server.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const authRoutes = require('./routes/auth');
+const orderRoutes = require('./routes/orders');
+const { poolConnect } = require('./db');
+
+const app = express();
+app.use(express.json());
+
+app.use('/api', authRoutes);
+app.use('/api/orders', orderRoutes);
+
+const port = process.env.PORT || 3000;
+
+poolConnect.then(() => {
+  app.listen(port, () => {
+    console.log(`Server running on port ${port}`);
+  });
+}).catch(err => {
+  console.error('Database connection failed', err);
+});


### PR DESCRIPTION
## Summary
- implement Node.js server with Express and MSSQL connection
- add authentication middleware and login route
- add order route for placing and retrieving user orders
- provide package.json with dependencies

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6886e5d98b88832c9189199c9492c66e